### PR TITLE
fix: update payment status from "belum terverifikasi" to "diproses" i…

### DIFF
--- a/src/api/services/admin.ts
+++ b/src/api/services/admin.ts
@@ -457,7 +457,7 @@ export class TeamsService {
     try {
       const response = await apiClient.patch<TeamInformationData>(
         `/admin/teams/${team_id}`,
-        { team_id: team_id, payment_status: "belum terverifikasi" }
+        { team_id: team_id, payment_status: "diproses" }
       );
 
       if (response.status.isSuccess) {

--- a/src/shared/utils/paymentStyles.ts
+++ b/src/shared/utils/paymentStyles.ts
@@ -3,9 +3,11 @@ export const getPaymentStatusStyle = (status: string) => {
         case "belum terverifikasi":
             return "px-2 py-1 rounded-md text-sm bg-slate-600 text-white";
         case "ditolak":
-            return "px-2 py-1 rounded-md text-sm bg-yellow-700 text-white";
+            return "px-2 py-1 rounded-md text-sm bg-red-700 text-white";
         case "terverifikasi":
             return "px-2 py-1 rounded-md text-sm bg-green-800 text-white";
+        case "diproses":
+            return "px-2 py-1 rounded-md text-sm bg-yellow-800 text-white";
         default:
             return "px-2 py-1 rounded-md text-sm bg-gray-200";
     }


### PR DESCRIPTION
This pull request introduces updates to payment status handling in the admin services and shared utilities. The changes include modifying the status values and their corresponding styles to better reflect the payment processing state.

Updates to payment status handling:

* [`src/api/services/admin.ts`](diffhunk://#diff-849378d985536255e534b8b572222f94f1dc006072ba67c75cdf541cdf6a7204L460-R460): Changed the `payment_status` value from `"belum terverifikasi"` to `"diproses"` in the `TeamsService` class to indicate payments are now in a processing state.

Styling updates for payment statuses:

* [`src/shared/utils/paymentStyles.ts`](diffhunk://#diff-80b4626e8c33539e9f66ab19598f6100657487164eae5eca371bf0cdf691738cL6-R10): Updated the style for the `"ditolak"` status to use a red background (`bg-red-700` instead of `bg-yellow-700`) for better visual distinction. Added a new style for the `"diproses"` status with a yellow background (`bg-yellow-800`).